### PR TITLE
(main) Add a codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# This will cause the code owners of this repo to be assigned review of any
+# opened PRs against the branches containing this file.
+# See https://help.github.com/en/articles/about-code-owners for info on how to
+# take ownership of parts of the code base that should be reviewed by another
+# team.
+
+*  @puppetlabs/support


### PR DESCRIPTION
This commit adds a CODEOWNERS file to the repo. This ensures the repo
compiles with the puppetlabs standards and the support team is denoted
as the maintainers of the repo.